### PR TITLE
Updated Readme to avoid TypeError in Python3.5+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ How to use it
     # Run the VAD on 10 ms of silence. The result should be False.
     sample_rate = 16000
     frame_duration = 10  # ms
-    frame = b'\x00\x00' * (sample_rate * frame_duration / 1000)
+    frame = b'\x00\x00' * int(sample_rate * frame_duration / 1000)
     print 'Contains speech: %s' % (vad.is_speech(frame, sample_rate)
 
 


### PR DESCRIPTION
Converted to `int` to avoid
```
TypeError                                 Traceback (most recent call last)
      sample_rate = 16000
      frame_duration = 10  # ms
----> frame = b'\x00\x00' * (sample_rate * frame_duration / 1000)
      print('Contains speech:', vad.is_speech(frame, sample_rate))

TypeError: can't multiply sequence by non-int of type 'float'
```