### PR TITLE
Avoid reading outside of memory in WebRtcVad_FindMinimum

### DIFF
--- a/cbits/webrtc/common_audio/vad/vad_sp.c
+++ b/cbits/webrtc/common_audio/vad/vad_sp.c
@@ -79,7 +79,7 @@ int16_t WebRtcVad_FindMinimum(VadInstT* self,
       age[i]++;
     } else {
       // Too old value. Remove from memory and shift larger values downwards.
-      for (j = i; j < 16; j++) {
+      for (j = i; j < 15; j++) {
         smallest_values[j] = smallest_values[j + 1];
         age[j] = age[j + 1];
       }


### PR DESCRIPTION
Has already been fixed by webrtc in 2019-10-17 (git SHA1 4970670c78efdf64048874c3bd34b3ebca7e65e7)
https://chromium.googlesource.com/external/webrtc/+/master/common_audio/vad/vad_sp.c#82