### PR TITLE
add requirement setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,9 @@ setup(
     ext_modules=[module],
     py_modules=['webrtcvad'],
     test_suite='nose.collector',
+    install_requires=[
+        'setuptools', # pkg_resources
+    ],
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example: $ pip install -e .[dev,test]


### PR DESCRIPTION
fix this runtime error:

```
  File "/lib/python3.10/site-packages/webrtcvad.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
