### PR TITLE
Fix potential null pointer derference

### DIFF
--- a/cbits/webrtc/common_audio/vad/webrtc_vad.c
+++ b/cbits/webrtc/common_audio/vad/webrtc_vad.c
@@ -23,6 +23,9 @@ static const int kMaxFrameLengthMs = 30;
 
 VadInst* WebRtcVad_Create() {
   VadInstT* self = (VadInstT*)malloc(sizeof(VadInstT));
+  if (self == NULL) {
+    return NULL;
+  }
 
   WebRtcSpl_Init();
   self->init_flag = 0;


### PR DESCRIPTION
`malloc` may return NULL, causing a null dereference at `self->init_flag`.

More downstream changes may be required, although it seems this is sufficient as `PyCapsule_New` can take `NULL` at [this place](https://github.com/wiseman/py-webrtcvad/blob/e283ca41df3a84b0e87fb1f5cb9b21580a286b09/cbits/pywebrtcvad.c#L21).