### PR TITLE
replace pkg_resources with importlib.metadata for version lookup

### DIFF
--- a/webrtcvad.py
+++ b/webrtcvad.py
@@ -1,11 +1,16 @@
-import pkg_resources
+try:
+    # Python 3.8+
+    from importlib.metadata import version
+except Exception:  # pragma: no cover
+    # Backport for Python < 3.8
+    from importlib_metadata import version
 
 import _webrtcvad
 
 __author__ = "John Wiseman jjwiseman@gmail.com"
 __copyright__ = "Copyright (C) 2016 John Wiseman"
 __license__ = "MIT"
-__version__ = pkg_resources.get_distribution('webrtcvad').version
+__version__ = version("webrtcvad")
 
 
 class Vad(object):


### PR DESCRIPTION
`pkg_resources` is deprecated and will be removed in Setuptools >=81
(around Dec 2025). This change switches to importlib.metadata for
retrieving the package version, avoiding runtime breakage once
pkg_resources is removed.

Behavior is unchanged: importing webrtcvad
still raises if distribution metadata is missing.